### PR TITLE
Fixed error while loading TIMESTAMP field from BigQueryToSpanner

### DIFF
--- a/src/main/java/com/mercari/solution/util/converter/RecordToStructConverter.java
+++ b/src/main/java/com/mercari/solution/util/converter/RecordToStructConverter.java
@@ -109,7 +109,7 @@ public class RecordToStructConverter {
             case LONG:
                 final Long longValue = (Long)value;
                 if(LogicalTypes.timestampMillis().equals(schema.getLogicalType())) {
-                    return builder.set(fieldName).to(isNullField ? null : convertMicrosecToTimestamp(longValue * 1000));
+                    return builder.set(fieldName).to(isNullField ? null : convertMicrosecToTimestamp(longValue));
                 } else if(LogicalTypes.timestampMicros().equals(schema.getLogicalType())) {
                     return builder.set(fieldName).to(isNullField ? null : convertMicrosecToTimestamp(longValue));
                 } else if(LogicalTypes.timeMicros().equals(schema.getLogicalType())) {


### PR DESCRIPTION
The following error appeared while writing BigQuery TIMESTAMP field  into Spanner TIMESTAMP field:
java.lang.RuntimeException: org.apache.beam.sdk.util.UserCodeException: java.lang.IllegalArgumentException: timestamp out of range: 1567669026000.  