### PR TITLE
version up junit.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ LICENSE file in the root directory of this source tree.
     <beam.version>2.25.0</beam.version>
     <hamcrest.version>1.3</hamcrest.version>
     <joda.version>2.4</joda.version>
-    <junit.version>4.13-beta-3</junit.version>
+    <junit.version>4.13.1</junit.version>
     <commons-csv.version>1.5</commons-csv.version>
     <googlecloud.bigquery.version>1.125.0</googlecloud.bigquery.version>
     <googlecloud.storage.version>1.113.4</googlecloud.storage.version>


### PR DESCRIPTION
# WHAT
Version up junit.

# WHY
Because the library version is outdated and insecure.